### PR TITLE
Add schedule to always have recent logs available

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,16 @@
-on: [push]
+on: 
+  push:
+  schedule:
+    - cron: 19 2 * * 6
 
 jobs:
   greenframe_action_workflow:
     runs-on: ubuntu-latest
     name: Run a GreenFrame CLI Action
     steps:
-      # To use this repository's private action,
-      # you must check out the repository
+      # To use this repository's local action you must check out the repository
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch all the git history
       - name: GreenFrame Analysis


### PR DESCRIPTION
Currently the logs are not viewable, since the workflow was last used 2 years ago. It would be nice to have then visible so users can find out what the CLI can do.